### PR TITLE
fix overlays parameter specification method

### DIFF
--- a/image.go
+++ b/image.go
@@ -463,12 +463,12 @@ func (c *Config) append(buf []byte) []byte {
 	}
 
 	if len(c.Overlays) > 0 {
-		buf = append(buf, 'l', '=', '(')
 		for _, overlay := range c.Overlays {
+			buf = append(buf, 'l', '=', '(')
 			buf = overlay.append(buf)
 			buf = append(buf, ',')
+			buf = append(buf[:len(buf)-1], ')', ',')
 		}
-		buf = append(buf[:len(buf)-1], ')', ',')
 	}
 
 	if c.Format != "" {

--- a/image_test.go
+++ b/image_test.go
@@ -315,7 +315,7 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
-			output: "l=(x=100,y=200%2fhttp%3A%2F%2Fexample.com%2F1.png,x=200,y=100%2fhttp%3A%2F%2Fexample.com%2F2.png)",
+			output: "l=(x=100,y=200%2fhttp%3A%2F%2Fexample.com%2F1.png),l=(x=200,y=100%2fhttp%3A%2F%2Fexample.com%2F2.png)",
 		},
 		{
 			config: &Config{


### PR DESCRIPTION
The current specification method causes an error.
The parameter created in the preview dashboard was split by l =
