### PR TITLE
Fix invalid path if empty config is specified

### DIFF
--- a/image.go
+++ b/image.go
@@ -543,7 +543,7 @@ func (img *Image) Sign() string {
 func (img *Image) pathAndSign() (string, string) {
 	buf := bufPool.Get().([]byte)[:0]
 	buf = append(buf, "/c/"...)
-	buf = img.Config.append(buf)
+	buf = append(buf, img.Config.String()...)
 	if len(buf) == len("/c/") {
 		buf = buf[:0]
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -64,6 +64,17 @@ func TestImage(t *testing.T) {
 					Host:   "p1-47e91401.imageflux.jp",
 					Secret: "testsigningsecret",
 				},
+				Path:   "/images/1.jpg",
+				Config: &Config{},
+			},
+			"https://p1-47e91401.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host:   "p1-47e91401.imageflux.jp",
+					Secret: "testsigningsecret",
+				},
 				Path: "/images/1.jpg",
 				Config: &Config{
 					Width: 200,


### PR DESCRIPTION
Currently, `SignedURL()` generates unexpected URL if `&Config{}` is specified in `Config`.

```golang
proxy := &Proxy{
	Host:   "p1-47e91401.imageflux.jp",
	Secret: "testsigningsecret",
}

// print https://p1-47e91401.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg
fmt.Println(proxy.Image.SignedURL("/images/1.jpg", nil)

// print https://p1-47e91401.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=,images/1.jpg
fmt.Println(proxy.Image.SignedURL("/images/1.jpg", &Config{})
```

In this case, I think the result should be same as when `Config` is `nil`. I changed a code so that both cases are the same.