### PR TITLE
update the domain name for demo

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -7,7 +7,7 @@ import (
 func BenchmarkImage(b *testing.B) {
 	img := &Image{
 		Proxy: &Proxy{
-			Host:   "p1-47e91401.imageflux.jp",
+			Host:   "demo.imageflux.jp",
 			Secret: "testsigningsecret",
 		},
 		Path: "/images/1.jpg",
@@ -28,49 +28,49 @@ func TestImage(t *testing.T) {
 		{
 			&Image{
 				Proxy: &Proxy{
-					Host: "p1-47e91401.imageflux.jp",
+					Host: "demo.imageflux.jp",
 				},
 				Path: "/images/1.jpg",
 			},
-			"https://p1-47e91401.imageflux.jp/images/1.jpg",
+			"https://demo.imageflux.jp/images/1.jpg",
 		},
 		{
 			&Image{
 				Proxy: &Proxy{
-					Host: "p1-47e91401.imageflux.jp",
+					Host: "demo.imageflux.jp",
 				},
 				Path: "/images/1.jpg",
 				Config: &Config{
 					Width: 200,
 				},
 			},
-			"https://p1-47e91401.imageflux.jp/c/w=200/images/1.jpg",
+			"https://demo.imageflux.jp/c/w=200/images/1.jpg",
 		},
 		{
 			&Image{
 				Proxy: &Proxy{
-					Host:   "p1-47e91401.imageflux.jp",
+					Host:   "demo.imageflux.jp",
 					Secret: "testsigningsecret",
 				},
 				Path: "/images/1.jpg",
 			},
-			"https://p1-47e91401.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
 		},
 		{
 			&Image{
 				Proxy: &Proxy{
-					Host:   "p1-47e91401.imageflux.jp",
+					Host:   "demo.imageflux.jp",
 					Secret: "testsigningsecret",
 				},
 				Path:   "/images/1.jpg",
 				Config: &Config{},
 			},
-			"https://p1-47e91401.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
 		},
 		{
 			&Image{
 				Proxy: &Proxy{
-					Host:   "p1-47e91401.imageflux.jp",
+					Host:   "demo.imageflux.jp",
 					Secret: "testsigningsecret",
 				},
 				Path: "/images/1.jpg",
@@ -78,7 +78,7 @@ func TestImage(t *testing.T) {
 					Width: 200,
 				},
 			},
-			"https://p1-47e91401.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
 		},
 	}
 


### PR DESCRIPTION
p1-47e91401.imageflux.jp is no longer available.
it is now demo.imageflux.jp