### PR TITLE
fix GOEXPERIMENT environment value

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Test
         run: go test -v -coverprofile=profile.cov ./...
+        env:
+          GOEXPERIMENT: ${{ matrix.goexperiment }}
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION
I've added GOEXPERIMENT https://github.com/shogo82148/go-imageflux/pull/49 into the build matrix, but it is not used.