### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1"
+          - "stable"
+          - "1.23"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"
@@ -17,12 +19,6 @@ jobs:
           - "1.16"
           - "1.15"
           - "1.14"
-        goexperiment: [""]
-        include:
-          # test with GOEXPERIMENT=loopvar
-          # https://github.com/golang/go/wiki/LoopvarExperiment
-          - go: "1.21"
-            goexperiment: "loopvar"
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v5
@@ -34,8 +30,6 @@ jobs:
 
       - name: Test
         run: go test -v -coverprofile=profile.cov ./...
-        env:
-          GOEXPERIMENT: ${{ matrix.goexperiment }}
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced testing framework for greater compatibility with recent Go versions by expanding the version matrix.
	- Simplified testing configuration by removing experimental parameters and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->