### PR TITLE
support Expires parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Height is height in pixel of the scaled image.
 	Height int
 
+	// Expires is the time when the image expires.
+	Expires time.Time
+
 	// DisableEnlarge disables enlarge.
 	DisableEnlarge bool
 
@@ -651,6 +654,11 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 	if c.Height != 0 {
 		buf = append(buf, "h="...)
 		buf = strconv.AppendInt(buf, int64(c.Height), 10)
+		buf = appendComma(buf, escapeComma)
+	}
+	if !c.Expires.IsZero() {
+		buf = append(buf, "expires="...)
+		buf = c.Expires.In(time.UTC).AppendFormat(buf, time.RFC3339)
 		buf = appendComma(buf, escapeComma)
 	}
 	if c.DisableEnlarge {
@@ -1404,6 +1412,7 @@ func (s *parseState) setValue(key, value string) error {
 			return fmt.Errorf("imageflux: invalid invert %q", value)
 		}
 
+	// Expires
 	case "expires":
 		expires, err := time.Parse(time.RFC3339, value)
 		if err != nil {
@@ -1412,6 +1421,7 @@ func (s *parseState) setValue(key, value string) error {
 		if !expires.Before(nowFunc()) {
 			return ErrExpired
 		}
+		s.config.Expires = expires
 
 	case "sig":
 		// if signature is already set, ignore this

--- a/config_test.go
+++ b/config_test.go
@@ -895,7 +895,9 @@ var parseConfigCases = []struct {
 
 	{
 		input: "expires=2023-06-24T09:22:59Z",
-		want:  &Config{},
+		want: &Config{
+			Expires: time.Date(2023, 6, 24, 9, 22, 59, 0, time.UTC),
+		},
 	},
 
 	{


### PR DESCRIPTION
This pull request introduces support for an `Expires` field in the `Config` struct within `config.go`, enabling functionality to set and validate expiration times for images. Key changes include adding the new field, updating relevant methods to handle expiration logic, and enhancing test cases to validate this feature.

### Addition of `Expires` field:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R36-R38): Added the `Expires` field to the `Config` struct to store the expiration time of an image.

### Updates to methods for expiration handling:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R659-R663): Updated the `append` method to include logic for appending the `Expires` field to the buffer if it is set.
* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R1415): Modified the `setValue` method to parse the `expires` key, validate the expiration time, and assign it to the `Expires` field in the `Config` struct. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R1415) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R1424)

### Enhancements to test cases:

* [`config_test.go`](diffhunk://#diff-4bb821dfaef1884915ee03c5488bded04807301bc3f41fc7001a078c330ae980L898-R900): Added test cases to verify the correct parsing and assignment of the `Expires` field in the `Config` struct.