### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/shogo82148/go-imageflux/security/code-scanning/1](https://github.com/shogo82148/go-imageflux/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is sufficient for checking out the code and running tests.
- Additional permissions may be required for the `shogo82148/actions-goveralls` action, depending on its functionality.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is appropriate since all jobs seem to require similar permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
