### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,7 @@
 name: reviewdog
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,6 +2,7 @@ name: reviewdog
 on: [pull_request]
 permissions:
   contents: read
+  pull-requests: write
 jobs:
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/shogo82148/go-imageflux/security/code-scanning/2](https://github.com/shogo82148/go-imageflux/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Since the workflow uses `reviewdog` and `actionlint`, it likely only needs read access to the repository contents. We will set `contents: read` as the permission. This change will ensure that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
