### PR TITLE
pin GitHub Actions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
       - id: list
-        uses: shogo82148/actions-go-fuzz/list@v1
+        uses: shogo82148/actions-go-fuzz/list@9694a8a3fd8c21af0fccba84b99d716027e81449 # v1.1.8
     outputs:
       fuzz-tests: ${{steps.list.outputs.fuzz-tests}}
 
@@ -31,11 +31,11 @@ jobs:
       matrix:
         include: ${{fromJson(needs.list.outputs.fuzz-tests)}}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
-      - uses: shogo82148/actions-go-fuzz/run@v1
+      - uses: shogo82148/actions-go-fuzz/run@9694a8a3fd8c21af0fccba84b99d716027e81449 # v1.1.8
         with:
           packages: ${{ matrix.package }}
           fuzz-regexp: ${{ matrix.func }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,8 +4,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
         with:
           reporter: github-pr-review
           level: warning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,18 +24,18 @@ jobs:
           - "1.14"
     steps:
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Test
         run: go test -v -coverprofile=profile.cov ./...
 
       - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
+        uses: shogo82148/actions-goveralls@e6875f831db61e6abffbd8df91a2eb6cd24b46c9 # v1.9.1
         with:
           path-to-profile: profile.cov
           parallel: true
@@ -47,6 +47,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: shogo82148/actions-goveralls@v1
+      - uses: shogo82148/actions-goveralls@e6875f831db61e6abffbd8df91a2eb6cd24b46c9 # v1.9.1
         with:
           parallel-finished: true


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use specific commit hashes for actions, ensuring reproducibility and stability. The changes affect workflows related to fuzz testing, code linting, and test coverage reporting.

### Workflow updates for reproducibility:

* [`.github/workflows/fuzz.yml`](diffhunk://#diff-05173c6260b3a634672ba19a936ae023b6635bf308b195d5eaf9b986021184d4L16-R21): Updated `actions/checkout`, `actions/setup-go`, and `shogo82148/actions-go-fuzz` actions to use specific commit hashes, including `v4.2.2`, `v5.5.0`, and `v1.1.8`, respectively. [[1]](diffhunk://#diff-05173c6260b3a634672ba19a936ae023b6635bf308b195d5eaf9b986021184d4L16-R21) [[2]](diffhunk://#diff-05173c6260b3a634672ba19a936ae023b6635bf308b195d5eaf9b986021184d4L34-R38)

* [`.github/workflows/reviewdog.yml`](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dL7-R8): Updated `actions/checkout` and `reviewdog/action-actionlint` actions to use specific commit hashes (`v4.2.2` and `v1.65.2`).

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L27-R38): Updated `actions/setup-go`, `actions/checkout`, and `shogo82148/actions-goveralls` actions to use specific commit hashes (`v5.5.0`, `v4.2.2`, and `v1.9.1`). [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L27-R38) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L50-R50)