### PR TITLE
truncate expires

### DIFF
--- a/config.go
+++ b/config.go
@@ -658,7 +658,7 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 	}
 	if !c.Expires.IsZero() {
 		buf = append(buf, "expires="...)
-		buf = c.Expires.In(time.UTC).AppendFormat(buf, time.RFC3339)
+		buf = c.Expires.In(time.UTC).Truncate(time.Second).AppendFormat(buf, time.RFC3339)
 		buf = appendComma(buf, escapeComma)
 	}
 	if c.DisableEnlarge {
@@ -1418,6 +1418,7 @@ func (s *parseState) setValue(key, value string) error {
 		if err != nil {
 			return fmt.Errorf("imageflux: invalid expires %q", value)
 		}
+		expires = expires.Truncate(time.Second)
 		if !expires.After(nowFunc()) {
 			return ErrExpired
 		}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,13 +1,13 @@
 //go:build go1.18
-// +build go1.18
 
 package imageflux
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func FuzzParseConfig(f *testing.F) {
@@ -41,8 +41,8 @@ func FuzzParseConfig(f *testing.F) {
 			c1.Format = FormatAuto
 		}
 
-		if !reflect.DeepEqual(c0, c1) {
-			t.Errorf("%q: c0 != c1: %v != %v", s, c0, c1)
+		if diff := cmp.Diff(c0, c1); diff != "" {
+			t.Errorf("%q: (-c0 +c1) %v", s, diff)
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/shogo82148/go-imageflux
 
-go 1.17
+go 1.21
+
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision handling for configuration expiration timestamps by truncating to whole-second intervals during serialization and parsing.

* **Chores**
  * Updated Go toolchain version requirement to 1.21.
  * Added testing dependency for enhanced assertion comparisons.

* **Tests**
  * Modernized fuzz test infrastructure with updated build constraints and detailed comparison output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->