### PR TITLE
make WithoutComma by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package imageflux
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -15,6 +16,8 @@ import (
 )
 
 const rectangleScale = 65536
+
+var comma = []byte("%2C") // percent-encoded comma
 
 // nowFunc is for testing.
 var nowFunc = time.Now
@@ -634,13 +637,13 @@ func (c *Config) String() string {
 		return "f=auto"
 	}
 	buf := bufPool.Get().(*[]byte)
-	*buf = c.append((*buf)[:0], false)
+	*buf = c.append((*buf)[:0])
 	str := string(*buf)
 	bufPool.Put(buf)
 	return str
 }
 
-func (c *Config) append(buf []byte, escapeComma bool) []byte {
+func (c *Config) append(buf []byte) []byte {
 	var zr image.Rectangle
 	var zp image.Point
 	if c == nil {
@@ -652,31 +655,31 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 	if c.Width != 0 {
 		buf = append(buf, "w="...)
 		buf = strconv.AppendInt(buf, int64(c.Width), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Height != 0 {
 		buf = append(buf, "h="...)
 		buf = strconv.AppendInt(buf, int64(c.Height), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if !c.Expires.IsZero() {
 		buf = append(buf, "expires="...)
 		buf = c.Expires.In(time.UTC).Truncate(time.Second).AppendFormat(buf, time.RFC3339)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.DisableEnlarge {
 		buf = append(buf, "u=0"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.AspectMode != AspectModeDefault {
 		buf = append(buf, "a="...)
 		buf = strconv.AppendInt(buf, int64(c.AspectMode-1), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.DevicePixelRatio != 0 {
 		buf = append(buf, "dpr="...)
 		buf = strconv.AppendFloat(buf, c.DevicePixelRatio, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// clipping parameters
@@ -689,7 +692,7 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendInt(buf, int64(ic.Max.X), 10)
 		buf = append(buf, ':')
 		buf = strconv.AppendInt(buf, int64(ic.Max.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if cm, ic := c.ClipMax, c.InputClipRatio; cm != zp && ic != zr {
 		x1 := float64(ic.Min.X) / float64(cm.X)
@@ -704,12 +707,12 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendFloat(buf, x2, 'f', -1, 64)
 		buf = append(buf, ':')
 		buf = strconv.AppendFloat(buf, y2, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if ig := c.InputOrigin; ig != OriginDefault {
 		buf = append(buf, "ig="...)
 		buf = strconv.AppendInt(buf, int64(ig), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c, oc := c.Clip, c.OutputClip; c != zr || oc != zr {
 		if oc == zr {
@@ -723,7 +726,7 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendInt(buf, int64(oc.Max.X), 10)
 		buf = append(buf, ':')
 		buf = strconv.AppendInt(buf, int64(oc.Max.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c, oc, cm := c.ClipRatio, c.OutputClipRatio, c.ClipMax; cm != zp && (c != zr || oc != zr) {
 		if oc == zr {
@@ -741,18 +744,18 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendFloat(buf, x2, 'f', -1, 64)
 		buf = append(buf, ':')
 		buf = strconv.AppendFloat(buf, y2, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if og := c.OutputOrigin; og != OriginDefault {
 		buf = append(buf, "og="...)
 		buf = strconv.AppendInt(buf, int64(og), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if c.Origin != OriginDefault {
 		buf = append(buf, "g="...)
 		buf = strconv.AppendInt(buf, int64(c.Origin), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Background != nil {
 		b := color.NRGBAModel.Convert(c.Background).(color.NRGBA)
@@ -762,14 +765,14 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 			buf = appendByte(buf, b.R)
 			buf = appendByte(buf, b.G)
 			buf = appendByte(buf, b.B)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "b="...)
 			buf = appendByte(buf, b.R)
 			buf = appendByte(buf, b.G)
 			buf = appendByte(buf, b.B)
 			buf = appendByte(buf, b.A)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
@@ -777,11 +780,11 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 	if ir := c.InputRotate; ir != RotateDefault {
 		if ir == RotateAuto {
 			buf = append(buf, "ir=auto"...)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "ir="...)
 			buf = strconv.AppendInt(buf, int64(ir), 10)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 	if r, or := c.Rotate, c.OutputRotate; r != RotateDefault || or != RotateDefault {
@@ -790,26 +793,26 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 		}
 		if or == RotateAuto {
 			buf = append(buf, "or=auto"...)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "or="...)
 			buf = strconv.AppendInt(buf, int64(or), 10)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
 	if c.Through != 0 {
 		buf = append(buf, "through="...)
 		buf = c.Through.append(buf)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if len(c.Overlays) > 0 {
 		for _, overlay := range c.Overlays {
 			buf = append(buf, "l=("...)
-			buf = overlay.append(buf, escapeComma)
+			buf = overlay.append(buf)
 			buf = append(buf, ')')
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
@@ -817,80 +820,78 @@ func (c *Config) append(buf []byte, escapeComma bool) []byte {
 	if c.Format != "" {
 		buf = append(buf, "f="...)
 		buf = append(buf, c.Format...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Quality != 0 {
 		buf = append(buf, "q="...)
 		buf = strconv.AppendInt(buf, int64(c.Quality), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.DisableOptimization {
 		buf = append(buf, "o=0"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Lossless {
 		buf = append(buf, "lossless=1"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.ExifOption != ExifOptionDefault {
 		buf = append(buf, "s="...)
 		buf = strconv.AppendInt(buf, int64(c.ExifOption), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// image filters
 	if c.Unsharp.Radius != 0 {
 		buf = append(buf, "unsharp="...)
 		buf = c.Unsharp.append(buf)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Blur.Radius != 0 {
 		buf = append(buf, "blur="...)
 		buf = c.Blur.append(buf)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.GrayScale != 0 {
 		buf = append(buf, "grayscale="...)
 		buf = strconv.AppendInt(buf, int64(c.GrayScale), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Sepia != 0 {
 		buf = append(buf, "sepia="...)
 		buf = strconv.AppendInt(buf, int64(c.Sepia), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Brightness != 0 {
 		buf = append(buf, "brightness="...)
 		buf = strconv.AppendInt(buf, int64(c.Brightness+100), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Contrast != 0 {
 		buf = append(buf, "contrast="...)
 		buf = strconv.AppendInt(buf, int64(c.Contrast+100), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c.Invert {
 		buf = append(buf, "invert=1"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if len(c.Texts) > 0 {
 		for _, text := range c.Texts {
 			buf = append(buf, "t=("...)
-			buf = text.append(buf, escapeComma)
+			buf = text.append(buf)
 			buf = append(buf, ')')
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
 	if len(buf) == l {
 		buf = append(buf, "f=auto"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
-	if escapeComma {
-		return buf[:len(buf)-3]
-	}
-	return buf[:len(buf)-1]
+	buf = bytes.TrimSuffix(buf, comma)
+	return buf
 }
 
 func appendByte(buf []byte, b byte) []byte {
@@ -898,11 +899,8 @@ func appendByte(buf []byte, b byte) []byte {
 	return append(buf, digits[b>>4], digits[b&0x0F])
 }
 
-func appendComma(buf []byte, escape bool) []byte {
-	if escape {
-		return append(buf, "%2C"...)
-	}
-	return append(buf, ',')
+func appendComma(buf []byte) []byte {
+	return append(buf, comma...)
 }
 
 func (a AspectMode) String() string {

--- a/config_test.go
+++ b/config_test.go
@@ -108,7 +108,7 @@ var configStringCases = []struct {
 			Width:  200,
 			Height: 200,
 		},
-		output: "w=200,h=200",
+		output: "w=200%2Ch=200",
 	},
 	{
 		config: &Config{
@@ -148,7 +148,7 @@ var configStringCases = []struct {
 			InputClip:   image.Rect(100, 150, 200, 250),
 			InputOrigin: OriginMiddleCenter,
 		},
-		output: "ic=100:150:200:250,ig=5",
+		output: "ic=100:150:200:250%2Cig=5",
 	},
 	{
 		config: &Config{
@@ -204,7 +204,7 @@ var configStringCases = []struct {
 			OutputClip:   image.Rect(100, 150, 200, 250),
 			OutputOrigin: OriginMiddleCenter,
 		},
-		output: "oc=100:150:200:250,og=5",
+		output: "oc=100:150:200:250%2Cog=5",
 	},
 
 	{
@@ -348,7 +348,7 @@ var configStringCases = []struct {
 				Offset: image.Pt(100, 200),
 			}},
 		},
-		output: "l=(x=100,y=200%2Fimages%2F1.png)",
+		output: "l=(x=100%2Cy=200%2Fimages%2F1.png)",
 	},
 	{
 		config: &Config{
@@ -358,7 +358,7 @@ var configStringCases = []struct {
 				OffsetMax:   image.Pt(100, 100),
 			}},
 		},
-		output: "l=(xr=0.25,yr=0.75%2Fimages%2F1.png)",
+		output: "l=(xr=0.25%2Cyr=0.75%2Fimages%2F1.png)",
 	},
 	{
 		config: &Config{
@@ -382,7 +382,7 @@ var configStringCases = []struct {
 				},
 			},
 		},
-		output: "l=(x=100,y=200%2Fimages%2F1.png),l=(x=200,y=100%2Fimages%2F2.png)",
+		output: "l=(x=100%2Cy=200%2Fimages%2F1.png)%2Cl=(x=200%2Cy=100%2Fimages%2F2.png)",
 	},
 	{
 		config: &Config{
@@ -514,7 +514,7 @@ var configStringCases = []struct {
 				},
 			},
 		},
-		output: "t=(font=Ryumin%20R-KL,size=30,f=ffffff,w=400,h=80,align=1,text=%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E3%81%8C%0A%E5%90%88%E6%88%90%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99)",
+		output: "t=(font=Ryumin%20R-KL%2Csize=30%2Cf=ffffff%2Cw=400%2Ch=80%2Calign=1%2Ctext=%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E3%81%8C%0A%E5%90%88%E6%88%90%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99)",
 	},
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func ExampleImage_SignedURL() {
 	fmt.Println(u)
 
 	// Output:
-	// https://demo.imageflux.jp/c/w=200,f=webp:auto/images/1.jpg
+	// https://demo.imageflux.jp/c/w=200%2Cf=webp:auto/images/1.jpg
 }
 
 func ExampleImage_SignedURL_signed() {
@@ -38,7 +38,7 @@ func ExampleImage_SignedURL_signed() {
 	fmt.Println(u)
 
 	// Output:
-	// https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg
+	// https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg
 }
 
 func ExampleImage_SignedURLWithoutComma() {

--- a/image.go
+++ b/image.go
@@ -34,39 +34,37 @@ type Image struct {
 	Expires time.Time
 }
 
-// SignedURL returns the URL of the image with the signature.
+// SignedURL returns the signed URL of the image.
+// As of v1.3.0, the URL no longer contains commas.
+// This is useful for the srcset attribute of an HTML img tag.
 func (img *Image) SignedURL() string {
-	path, s := img.pathAndSign(false)
-	if s == "" {
-		return "https://" + img.Proxy.Host + path
-	}
-	return "https://" + img.Proxy.Host + "/c/sig=" + s + "," + strings.TrimPrefix(path, "/c/")
-}
-
-// SignedURLWithoutComma is same as SignedURL but
-// the url doesn't contain comma.
-// It is useful for srcset of HTML img tag.
-func (img *Image) SignedURLWithoutComma() string {
-	path, s := img.pathAndSign(true)
+	path, s := img.pathAndSign()
 	if s == "" {
 		return "https://" + img.Proxy.Host + path
 	}
 	return "https://" + img.Proxy.Host + "/c/sig=" + s + "%2C" + strings.TrimPrefix(path, "/c/")
 }
 
+// SignedURLWithoutComma is same as SignedURL.
+//
+// It is provided for backward compatibility.
+func (img *Image) SignedURLWithoutComma() string {
+	return img.SignedURL()
+}
+
 // Sign returns the signature.
 func (img *Image) Sign() string {
-	_, s := img.pathAndSign(false)
+	_, s := img.pathAndSign()
 	return s
 }
 
-func (img *Image) pathAndSign(escapeComma bool) (string, string) {
+func (img *Image) pathAndSign() (string, string) {
 	pbuf := bufPool.Get().(*[]byte)
 	buf := (*pbuf)[:0]
 	buf = append(buf, "/c/"...)
-	buf = img.Config.append(buf, escapeComma)
+	buf = img.Config.append(buf)
 	if !img.Expires.IsZero() {
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 		buf = append(buf, "expires="...)
 		buf = img.Expires.UTC().AppendFormat(buf, time.RFC3339)
 	}
@@ -103,7 +101,7 @@ func (img *Image) String() string {
 	buf = append(buf, "https://"...)
 	buf = append(buf, img.Proxy.Host...)
 	buf = append(buf, "/c/"...)
-	buf = img.Config.append(buf, false)
+	buf = img.Config.append(buf)
 	if !img.Expires.IsZero() {
 		buf = append(buf, ",expires="...)
 		buf = img.Expires.UTC().AppendFormat(buf, time.RFC3339)

--- a/image.go
+++ b/image.go
@@ -103,7 +103,8 @@ func (img *Image) String() string {
 	buf = append(buf, "/c/"...)
 	buf = img.Config.append(buf)
 	if !img.Expires.IsZero() {
-		buf = append(buf, ",expires="...)
+		buf = appendComma(buf)
+		buf = append(buf, "expires="...)
 		buf = img.Expires.UTC().AppendFormat(buf, time.RFC3339)
 	}
 	if len(img.Path) == 0 || img.Path[0] != '/' {

--- a/image_test.go
+++ b/image_test.go
@@ -57,7 +57,7 @@ func TestImage_SignedURL(t *testing.T) {
 				},
 				Path: "/images/1.jpg",
 			},
-			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=,f=auto/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=%2Cf=auto/images/1.jpg",
 		},
 		{
 			&Image{
@@ -68,7 +68,7 @@ func TestImage_SignedURL(t *testing.T) {
 				Path:   "/images/1.jpg",
 				Config: &Config{},
 			},
-			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=,f=auto/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=%2Cf=auto/images/1.jpg",
 		},
 		{
 			&Image{
@@ -81,7 +81,7 @@ func TestImage_SignedURL(t *testing.T) {
 					Width: 200,
 				},
 			},
-			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg",
 		},
 		{
 			&Image{
@@ -89,9 +89,9 @@ func TestImage_SignedURL(t *testing.T) {
 					Host: "demo.imageflux.jp",
 				},
 				Path:    "/images/1.jpg",
-				Expires: time.Date(2023, 6, 24, 18, 23, 0, 123456789, jst),
+				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
 			},
-			"https://demo.imageflux.jp/c/f=auto,expires=2023-06-24T09:23:00Z/images/1.jpg",
+			"https://demo.imageflux.jp/c/f=auto%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
 		},
 		{
 			&Image{
@@ -103,9 +103,9 @@ func TestImage_SignedURL(t *testing.T) {
 				Config: &Config{
 					Width: 200,
 				},
-				Expires: time.Date(2023, 6, 24, 18, 23, 0, 123456789, jst),
+				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
 			},
-			"https://demo.imageflux.jp/c/sig=1.dFGx33tPqUTZLhzxcbOY5_f-afI9EBDga8rwbmMsW2o=,w=200,expires=2023-06-24T09:23:00Z/images/1.jpg",
+			"https://demo.imageflux.jp/c/sig=1.UfcQfFM5BpKkPXAs-SG96xA7Cm2JWbjwhl32AdhsgWM=%2Cw=200%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
 		},
 		{
 			&Image{
@@ -124,7 +124,7 @@ func TestImage_SignedURL(t *testing.T) {
 					Format: FormatWebPAuto,
 				},
 			},
-			"https://demo.imageflux.jp/c/w=400,l=(w=300%2Fimages%2F1.png),f=webp:auto/bridge.jpg",
+			"https://demo.imageflux.jp/c/w=400%2Cl=(w=300%2Fimages%2F1.png)%2Cf=webp:auto/bridge.jpg",
 		},
 	}
 

--- a/image_test.go
+++ b/image_test.go
@@ -294,7 +294,7 @@ func TestImage_String(t *testing.T) {
 				Path:    "/images/1.jpg",
 				Expires: time.Date(2023, 6, 24, 18, 23, 0, 123456789, jst),
 			},
-			"https://demo.imageflux.jp/c/f=auto,expires=2023-06-24T09:23:00Z/images/1.jpg",
+			"https://demo.imageflux.jp/c/f=auto%2Cexpires=2023-06-24T09:23:00Z/images/1.jpg",
 		},
 	}
 

--- a/overlay.go
+++ b/overlay.go
@@ -1,6 +1,7 @@
 package imageflux
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"image/color"
@@ -110,32 +111,31 @@ type Overlay struct {
 }
 
 func (o Overlay) String() string {
-	return string(o.append([]byte{}, false))
+	return string(o.append(nil))
 }
 
-func (o Overlay) append(buf []byte, escapeComma bool) []byte {
+func (o Overlay) append(buf []byte) []byte {
 	var zr image.Rectangle
 	var zp image.Point
 
-	l := len(buf)
 	if o.Width != 0 {
 		buf = append(buf, "w="...)
 		buf = strconv.AppendInt(buf, int64(o.Width), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.Height != 0 {
 		buf = append(buf, "h="...)
 		buf = strconv.AppendInt(buf, int64(o.Height), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.DisableEnlarge {
 		buf = append(buf, "u=0"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.AspectMode != AspectModeDefault {
 		buf = append(buf, "a="...)
 		buf = strconv.AppendInt(buf, int64(o.AspectMode-1), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// clipping parameters
@@ -148,7 +148,7 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendInt(buf, int64(ic.Max.X), 10)
 		buf = append(buf, ':')
 		buf = strconv.AppendInt(buf, int64(ic.Max.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if cm, ic := o.ClipMax, o.InputClipRatio; cm != zp && ic != zr {
 		x1 := float64(ic.Min.X) / float64(cm.X)
@@ -163,12 +163,12 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendFloat(buf, x2, 'f', -1, 64)
 		buf = append(buf, ':')
 		buf = strconv.AppendFloat(buf, y2, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if ig := o.InputOrigin; ig != OriginDefault {
 		buf = append(buf, "ig="...)
 		buf = strconv.AppendInt(buf, int64(ig), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c, oc := o.Clip, o.OutputClip; c != zr || oc != zr {
 		if oc == zr {
@@ -182,7 +182,7 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendInt(buf, int64(oc.Max.X), 10)
 		buf = append(buf, ':')
 		buf = strconv.AppendInt(buf, int64(oc.Max.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if c, oc, cm := o.ClipRatio, o.OutputClipRatio, o.ClipMax; cm != zp && (c != zr || oc != zr) {
 		if oc == zr {
@@ -200,18 +200,18 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 		buf = strconv.AppendFloat(buf, x2, 'f', -1, 64)
 		buf = append(buf, ':')
 		buf = strconv.AppendFloat(buf, y2, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if og := o.OutputOrigin; og != OriginDefault {
 		buf = append(buf, "og="...)
 		buf = strconv.AppendInt(buf, int64(og), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if o.Origin != OriginDefault {
 		buf = append(buf, 'g', '=')
 		buf = strconv.AppendInt(buf, int64(o.Origin), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.Background != nil {
 		b := color.NRGBAModel.Convert(o.Background).(color.NRGBA)
@@ -221,14 +221,14 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 			buf = appendByte(buf, b.R)
 			buf = appendByte(buf, b.G)
 			buf = appendByte(buf, b.B)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "b="...)
 			buf = appendByte(buf, b.R)
 			buf = appendByte(buf, b.G)
 			buf = appendByte(buf, b.B)
 			buf = appendByte(buf, b.A)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
@@ -236,11 +236,11 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 	if ir := o.InputRotate; ir != RotateDefault {
 		if ir == RotateAuto {
 			buf = append(buf, "ir=auto"...)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "ir="...)
 			buf = strconv.AppendInt(buf, int64(ir), 10)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 	if r, or := o.Rotate, o.OutputRotate; r != RotateDefault || or != RotateDefault {
@@ -249,36 +249,36 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 		}
 		if or == RotateAuto {
 			buf = append(buf, "or=auto"...)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		} else {
 			buf = append(buf, "or="...)
 			buf = strconv.AppendInt(buf, int64(or), 10)
-			buf = appendComma(buf, escapeComma)
+			buf = appendComma(buf)
 		}
 	}
 
 	if o.Offset != zp {
 		buf = append(buf, "x="...)
 		buf = strconv.AppendInt(buf, int64(o.Offset.X), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 		buf = append(buf, "y="...)
 		buf = strconv.AppendInt(buf, int64(o.Offset.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.OffsetRatio != zp && o.OffsetMax != zp {
 		x := float64(o.OffsetRatio.X) / float64(o.OffsetMax.X)
 		y := float64(o.OffsetRatio.Y) / float64(o.OffsetMax.Y)
 		buf = append(buf, "xr="...)
 		buf = strconv.AppendFloat(buf, x, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 		buf = append(buf, "yr="...)
 		buf = strconv.AppendFloat(buf, y, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if o.OverlayOrigin != OriginDefault {
 		buf = append(buf, "lg="...)
 		buf = strconv.AppendInt(buf, int64(o.OverlayOrigin), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// mask
@@ -289,17 +289,11 @@ func (o Overlay) append(buf []byte, escapeComma bool) []byte {
 			buf = append(buf, ':')
 			buf = strconv.AppendInt(buf, int64(o.PaddingMode), 10)
 		}
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// remove trailing comma
-	if len(buf) != l {
-		if escapeComma {
-			buf = buf[:len(buf)-3]
-		} else {
-			buf = buf[:len(buf)-1]
-		}
-	}
+	buf = bytes.TrimSuffix(buf, comma)
 
 	path := o.Path
 	if path == "" {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -18,7 +18,7 @@ func TestOverlay(t *testing.T) {
 				Height: 200,
 				Path:   "images/1.png",
 			},
-			output: "w=100,h=200%2Fimages%2F1.png",
+			output: "w=100%2Ch=200%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{
@@ -26,7 +26,7 @@ func TestOverlay(t *testing.T) {
 				Height: 200,
 				Path:   "/images/1.png",
 			},
-			output: "w=100,h=200%2Fimages%2F1.png",
+			output: "w=100%2Ch=200%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{
@@ -63,7 +63,7 @@ func TestOverlay(t *testing.T) {
 				InputOrigin: OriginMiddleCenter,
 				Path:        "images/1.png",
 			},
-			output: "ic=100:200:300:400,ig=5%2Fimages%2F1.png",
+			output: "ic=100:200:300:400%2Cig=5%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{
@@ -126,7 +126,7 @@ func TestOverlay(t *testing.T) {
 				OutputOrigin: OriginMiddleCenter,
 				Path:         "images/1.png",
 			},
-			output: "oc=100:150:200:250,og=5%2Fimages%2F1.png",
+			output: "oc=100:150:200:250%2Cog=5%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{
@@ -203,7 +203,7 @@ func TestOverlay(t *testing.T) {
 				Offset: image.Pt(100, 200),
 				Path:   "images/1.png",
 			},
-			output: "x=100,y=200%2Fimages%2F1.png",
+			output: "x=100%2Cy=200%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{
@@ -211,7 +211,7 @@ func TestOverlay(t *testing.T) {
 				OffsetMax:   image.Pt(100, 100),
 				Path:        "images/1.png",
 			},
-			output: "xr=0.25,yr=0.75%2Fimages%2F1.png",
+			output: "xr=0.25%2Cyr=0.75%2Fimages%2F1.png",
 		},
 		{
 			overlay: &Overlay{

--- a/text.go
+++ b/text.go
@@ -76,10 +76,10 @@ type Text struct {
 }
 
 func (t *Text) String() string {
-	return string(t.append(nil, false))
+	return string(t.append(nil))
 }
 
-func (t *Text) append(buf []byte, escapeComma bool) []byte {
+func (t *Text) append(buf []byte) []byte {
 	var zp image.Point
 
 	if t == nil || t.Text == "" {
@@ -89,13 +89,13 @@ func (t *Text) append(buf []byte, escapeComma bool) []byte {
 	if t.Font != nil && t.Font.Name != "" {
 		buf = append(buf, "font="...)
 		buf = t.Font.append(buf)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Size != 0 {
 		buf = append(buf, "size="...)
 		buf = strconv.AppendFloat(buf, t.Size, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Foreground != nil {
@@ -113,7 +113,7 @@ func (t *Text) append(buf []byte, escapeComma bool) []byte {
 			buf = appendByte(buf, f.B)
 			buf = appendByte(buf, f.A)
 		}
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Background != nil {
@@ -131,82 +131,82 @@ func (t *Text) append(buf []byte, escapeComma bool) []byte {
 			buf = appendByte(buf, b.B)
 			buf = appendByte(buf, b.A)
 		}
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Width != 0 {
 		buf = append(buf, "w="...)
 		buf = strconv.AppendInt(buf, int64(t.Width), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if t.Height != 0 {
 		buf = append(buf, "h="...)
 		buf = strconv.AppendInt(buf, int64(t.Height), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.LineSpacing != 0 {
 		buf = append(buf, "linespacing="...)
 		buf = strconv.AppendFloat(buf, t.LineSpacing, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Align != 0 {
 		buf = append(buf, "align="...)
 		buf = strconv.AppendInt(buf, int64(t.Align), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Direction != 0 {
 		buf = append(buf, "dir="...)
 		buf = strconv.AppendInt(buf, int64(t.Direction), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Wrap != 0 {
 		buf = append(buf, "wrap="...)
 		buf = strconv.AppendInt(buf, int64(t.Wrap), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Ellipsize {
 		buf = append(buf, "ellipsize=1"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Justify {
 		buf = append(buf, "justify=1"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Strike {
 		buf = append(buf, "strike=1"...)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.Offset != zp {
 		buf = append(buf, "x="...)
 		buf = strconv.AppendInt(buf, int64(t.Offset.X), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 		buf = append(buf, "y="...)
 		buf = strconv.AppendInt(buf, int64(t.Offset.Y), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 	if t.OffsetRatio != zp && t.OffsetMax.X != 0 && t.OffsetMax.Y != 0 {
 		x := float64(t.OffsetRatio.X) / float64(t.OffsetMax.X)
 		y := float64(t.OffsetRatio.Y) / float64(t.OffsetMax.Y)
 		buf = append(buf, "xr="...)
 		buf = strconv.AppendFloat(buf, x, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 		buf = append(buf, "yr="...)
 		buf = strconv.AppendFloat(buf, y, 'f', -1, 64)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	if t.OverlayOrigin != OriginDefault {
 		buf = append(buf, "lg="...)
 		buf = strconv.AppendInt(buf, int64(t.OverlayOrigin), 10)
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// mask
@@ -217,7 +217,7 @@ func (t *Text) append(buf []byte, escapeComma bool) []byte {
 			buf = append(buf, ':')
 			buf = strconv.AppendInt(buf, int64(t.PaddingMode), 10)
 		}
-		buf = appendComma(buf, escapeComma)
+		buf = appendComma(buf)
 	}
 
 	// text MUST be the last parameter because it can contain any character.
@@ -266,7 +266,8 @@ func (f *Font) append(buf []byte) []byte {
 		instance := url.PathEscape(f.Instance)
 		buf = append(buf, '(')
 		buf = append(buf, name...)
-		buf = append(buf, ",instance="...)
+		buf = appendComma(buf)
+		buf = append(buf, "instance="...)
 		buf = append(buf, instance...)
 		buf = append(buf, ')')
 		return buf
@@ -282,7 +283,8 @@ func (f *Font) append(buf []byte) []byte {
 	buf = append(buf, '(')
 	buf = append(buf, name...)
 	for _, tag := range tags {
-		buf = append(buf, ",var="...)
+		buf = appendComma(buf)
+		buf = append(buf, "var="...)
 		buf = append(buf, url.PathEscape(tag)...)
 		buf = append(buf, ':')
 		buf = strconv.AppendFloat(buf, f.Variables[tag], 'f', -1, 64)

--- a/text_test.go
+++ b/text_test.go
@@ -28,7 +28,7 @@ func TestFont_String(t *testing.T) {
 				Name:     "DriveFlux",
 				Instance: "B Italic",
 			},
-			expected: "(DriveFlux,instance=B%20Italic)",
+			expected: "(DriveFlux%2Cinstance=B%20Italic)",
 		},
 		{
 			font: &Font{
@@ -40,7 +40,7 @@ func TestFont_String(t *testing.T) {
 					"slnt": -16,
 				},
 			},
-			expected: "(DriveFlux,var=CNTR:0,var=SMTH:0,var=slnt:-16,var=wght:700)",
+			expected: "(DriveFlux%2Cvar=CNTR:0%2Cvar=SMTH:0%2Cvar=slnt:-16%2Cvar=wght:700)",
 		},
 	}
 
@@ -164,7 +164,7 @@ func TestText_String(t *testing.T) {
 				Size:   12,
 				Text:   "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,w=400,h=100,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cw=400%2Ch=100%2Ctext=Hello%2C%20world%21",
 		},
 
 		// Named instance with variable font
@@ -179,7 +179,7 @@ func TestText_String(t *testing.T) {
 				Size:   12,
 				Text:   "Hello, world!",
 			},
-			expected: "font=(DriveFlux,instance=B%20Italic),size=12,w=400,h=100,text=Hello%2C%20world%21",
+			expected: "font=(DriveFlux%2Cinstance=B%20Italic)%2Csize=12%2Cw=400%2Ch=100%2Ctext=Hello%2C%20world%21",
 		},
 
 		// Variable font with variable values
@@ -199,7 +199,7 @@ func TestText_String(t *testing.T) {
 				Size:   12,
 				Text:   "Hello, world!",
 			},
-			expected: "font=(DriveFlux,var=CNTR:0,var=SMTH:0,var=slnt:-16,var=wght:700),size=12,w=400,h=100,text=Hello%2C%20world%21",
+			expected: "font=(DriveFlux%2Cvar=CNTR:0%2Cvar=SMTH:0%2Cvar=slnt:-16%2Cvar=wght:700)%2Csize=12%2Cw=400%2Ch=100%2Ctext=Hello%2C%20world%21",
 		},
 
 		// Transparent foreground and background colors
@@ -225,7 +225,7 @@ func TestText_String(t *testing.T) {
 				},
 				Text: "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,f=112233,b=445566,w=400,h=100,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cf=112233%2Cb=445566%2Cw=400%2Ch=100%2Ctext=Hello%2C%20world%21",
 		},
 		{
 			text: &Text{
@@ -249,7 +249,7 @@ func TestText_String(t *testing.T) {
 				},
 				Text: "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,f=1122337f,b=4455667f,w=400,h=100,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cf=1122337f%2Cb=4455667f%2Cw=400%2Ch=100%2Ctext=Hello%2C%20world%21",
 		},
 
 		{
@@ -269,7 +269,7 @@ func TestText_String(t *testing.T) {
 				Strike:      true,
 				Text:        "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,w=400,h=100,linespacing=1.5,align=1,dir=1,wrap=2,ellipsize=1,justify=1,strike=1,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cw=400%2Ch=100%2Clinespacing=1.5%2Calign=1%2Cdir=1%2Cwrap=2%2Cellipsize=1%2Cjustify=1%2Cstrike=1%2Ctext=Hello%2C%20world%21",
 		},
 
 		// offset
@@ -284,7 +284,7 @@ func TestText_String(t *testing.T) {
 				Offset: image.Point{X: 10, Y: 20},
 				Text:   "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,w=400,h=100,x=10,y=20,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cw=400%2Ch=100%2Cx=10%2Cy=20%2Ctext=Hello%2C%20world%21",
 		},
 		{
 			text: &Text{
@@ -298,7 +298,7 @@ func TestText_String(t *testing.T) {
 				OffsetMax:   image.Point{X: 2, Y: 2},
 				Text:        "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=12,w=400,h=100,xr=0.5,yr=0.5,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=12%2Cw=400%2Ch=100%2Cxr=0.5%2Cyr=0.5%2Ctext=Hello%2C%20world%21",
 		},
 
 		// Mask
@@ -316,7 +316,7 @@ func TestText_String(t *testing.T) {
 				PaddingMode: PaddingModeLeave,
 				Text:        "Hello, world!",
 			},
-			expected: "font=%E6%96%B0%E3%82%B4%20R,size=30,f=000000,b=ffffff,w=400,h=100,mask=black:1,text=Hello%2C%20world%21",
+			expected: "font=%E6%96%B0%E3%82%B4%20R%2Csize=30%2Cf=000000%2Cb=ffffff%2Cw=400%2Ch=100%2Cmask=black:1%2Ctext=Hello%2C%20world%21",
 		},
 	}
 


### PR DESCRIPTION
"," is treated as a reserved character in RFC 3986, and URLs containing "," may have compatibility issues.
For example, the `srcset` attribute of an `img` tag requires a comma-separated list of URLs, but it will not work correctly if the URLs themselves contain commas.

Therefore, we are making the generation of URLs without "," the default behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URLs now consistently use percent-encoded commas (%2C) as separators across generated image commands, overlays, text layers, and signed URLs. This yields stable, correctly encoded output for parameterized image operations, examples, and tooling that consume these URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->