### PR TITLE
Optimize signed url

### DIFF
--- a/image.go
+++ b/image.go
@@ -74,13 +74,18 @@ func (img *Image) pathAndSign() (string, string) {
 	buf = append(buf, img.Path...)
 	path := string(buf)
 
-	if img.Proxy.Secret == "" {
+	secret := img.Proxy.SecretBytes
+	if len(secret) == 0 && img.Proxy.Secret != "" {
+		secret = []byte(img.Proxy.Secret)
+	}
+
+	if len(secret) == 0 {
 		*pbuf = buf
 		bufPool.Put(pbuf)
 		return path, ""
 	}
 
-	mac := hmac.New(sha256.New, []byte(img.Proxy.Secret))
+	mac := hmac.New(sha256.New, secret)
 	mac.Write(buf)
 	buf = mac.Sum(buf[:0])
 	buf2 := make([]byte, len("1.")+base64.URLEncoding.EncodedLen(len(buf)))

--- a/image.go
+++ b/image.go
@@ -88,7 +88,8 @@ func (img *Image) pathAndSign() (string, string) {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(buf)
 	buf = mac.Sum(buf[:0])
-	buf2 := make([]byte, len("1.")+base64.URLEncoding.EncodedLen(len(buf)))
+
+	var buf2 [46]byte // 2 bytes for "1.", and 44 bytes for base64 encoding of 32 bytes.
 	buf2[0] = '1'
 	buf2[1] = '.'
 	base64.URLEncoding.Encode(buf2[2:], buf)

--- a/image_test.go
+++ b/image_test.go
@@ -52,6 +52,85 @@ func TestImage_SignedURL(t *testing.T) {
 		{
 			&Image{
 				Proxy: &Proxy{
+					Host:        "demo.imageflux.jp",
+					SecretBytes: []byte("testsigningsecret"),
+				},
+				Path: "/images/1.jpg",
+			},
+			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=%2Cf=auto/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host:        "demo.imageflux.jp",
+					SecretBytes: []byte("testsigningsecret"),
+				},
+				Path:   "/images/1.jpg",
+				Config: &Config{},
+			},
+			"https://demo.imageflux.jp/c/sig=1.tbCHoq4CHTiwxkfATFMnYqrJ7jcjG4D34B_oPQkzf-k=%2Cf=auto/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host:        "demo.imageflux.jp",
+					SecretBytes: []byte("testsigningsecret"),
+				},
+				Path: "/images/1.jpg",
+				Config: &Config{
+					Width: 200,
+				},
+			},
+			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host: "demo.imageflux.jp",
+				},
+				Path:    "/images/1.jpg",
+				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
+			},
+			"https://demo.imageflux.jp/c/f=auto%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host:        "demo.imageflux.jp",
+					SecretBytes: []byte("testsigningsecret"),
+				},
+				Path: "/images/1.jpg",
+				Config: &Config{
+					Width: 200,
+				},
+				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
+			},
+			"https://demo.imageflux.jp/c/sig=1.UfcQfFM5BpKkPXAs-SG96xA7Cm2JWbjwhl32AdhsgWM=%2Cw=200%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
+		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host: "demo.imageflux.jp",
+				},
+				Path: "/bridge.jpg",
+				Config: &Config{
+					Width: 400,
+					Overlays: []*Overlay{
+						{
+							Width: 300,
+							URL:   "images/1.png",
+						},
+					},
+					Format: FormatWebPAuto,
+				},
+			},
+			"https://demo.imageflux.jp/c/w=400%2Cl=(w=300%2Fimages%2F1.png)%2Cf=webp:auto/bridge.jpg",
+		},
+
+		// tests for backward compatibility with Secret field.
+		{
+			&Image{
+				Proxy: &Proxy{
 					Host:   "demo.imageflux.jp",
 					Secret: "testsigningsecret",
 				},
@@ -82,49 +161,6 @@ func TestImage_SignedURL(t *testing.T) {
 				},
 			},
 			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg",
-		},
-		{
-			&Image{
-				Proxy: &Proxy{
-					Host: "demo.imageflux.jp",
-				},
-				Path:    "/images/1.jpg",
-				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
-			},
-			"https://demo.imageflux.jp/c/f=auto%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
-		},
-		{
-			&Image{
-				Proxy: &Proxy{
-					Host:   "demo.imageflux.jp",
-					Secret: "testsigningsecret",
-				},
-				Path: "/images/1.jpg",
-				Config: &Config{
-					Width: 200,
-				},
-				Expires: time.Date(9999, 12, 31, 23, 59, 59, 123456789, jst),
-			},
-			"https://demo.imageflux.jp/c/sig=1.UfcQfFM5BpKkPXAs-SG96xA7Cm2JWbjwhl32AdhsgWM=%2Cw=200%2Cexpires=9999-12-31T14:59:59Z/images/1.jpg",
-		},
-		{
-			&Image{
-				Proxy: &Proxy{
-					Host: "demo.imageflux.jp",
-				},
-				Path: "/bridge.jpg",
-				Config: &Config{
-					Width: 400,
-					Overlays: []*Overlay{
-						{
-							Width: 300,
-							URL:   "images/1.png",
-						},
-					},
-					Format: FormatWebPAuto,
-				},
-			},
-			"https://demo.imageflux.jp/c/w=400%2Cl=(w=300%2Fimages%2F1.png)%2Cf=webp:auto/bridge.jpg",
 		},
 	}
 

--- a/image_test.go
+++ b/image_test.go
@@ -162,6 +162,21 @@ func TestImage_SignedURL(t *testing.T) {
 			},
 			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg",
 		},
+		{
+			&Image{
+				Proxy: &Proxy{
+					Host:        "demo.imageflux.jp",
+					SecretBytes: []byte("testsigningsecret"),
+					Secret:      "invalid", // Secret field is ignored when SecretBytes is set.
+				},
+				Path: "/images/1.jpg",
+				Config: &Config{
+					Width: 200,
+				},
+			},
+			// Should match SecretBytes signature, not Secret signature
+			"https://demo.imageflux.jp/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=%2Cw=200/images/1.jpg",
+		},
 	}
 
 	for _, c := range cases {

--- a/image_test.go
+++ b/image_test.go
@@ -10,8 +10,8 @@ var jst *time.Location = time.FixedZone("Asia/Tokyo", 9*60*60)
 func BenchmarkImage(b *testing.B) {
 	img := &Image{
 		Proxy: &Proxy{
-			Host:   "demo.imageflux.jp",
-			Secret: "testsigningsecret",
+			Host:        "demo.imageflux.jp",
+			SecretBytes: []byte("testsigningsecret"),
 		},
 		Path: "/images/1.jpg",
 		Config: &Config{

--- a/proxy.go
+++ b/proxy.go
@@ -2,9 +2,15 @@ package imageflux
 
 // Proxy is a proxy of ImageFlux.
 type Proxy struct {
+	// Host is the host of the proxy server.
 	Host string
 
+	// SecretBytes is signing secret.
+	SecretBytes []byte
+
 	// Secret is signing secret.
+	//
+	// Deprecated: Use SecretBytes instead.
 	Secret string
 }
 
@@ -25,7 +31,12 @@ func (p *Proxy) Parse(path string, signature string) (*Image, error) {
 		signature: signature,
 	}
 
-	if p.Secret == "" {
+	secret := p.SecretBytes
+	if len(secret) == 0 && p.Secret != "" {
+		secret = []byte(p.Secret)
+	}
+
+	if len(secret) == 0 {
 		c, rest, err := state.parseConfig()
 		if err != nil {
 			return nil, err
@@ -37,7 +48,7 @@ func (p *Proxy) Parse(path string, signature string) (*Image, error) {
 		}, nil
 	}
 
-	c, rest, err := state.parseConfigAndVerifySignature([]byte(p.Secret))
+	c, rest, err := state.parseConfigAndVerifySignature(secret)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -25,7 +25,7 @@ func TestProxy_Parse(t *testing.T) {
 		{
 			input: "/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -35,7 +35,7 @@ func TestProxy_Parse(t *testing.T) {
 		{
 			input: "/c/w=200,sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -45,7 +45,7 @@ func TestProxy_Parse(t *testing.T) {
 		{
 			input: "/c/w=200%2csig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -55,7 +55,7 @@ func TestProxy_Parse(t *testing.T) {
 		{
 			input: "/c/w=200%2Csig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -66,7 +66,7 @@ func TestProxy_Parse(t *testing.T) {
 			input:     "/c/w=200/images/1.jpg",
 			signature: "1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -77,7 +77,7 @@ func TestProxy_Parse(t *testing.T) {
 			input:     "/c/sig=1.invalid,w=200/images/1.jpg",
 			signature: "1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{
 				Width: 200,
@@ -87,7 +87,7 @@ func TestProxy_Parse(t *testing.T) {
 		{
 			input: "/c/sig=1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{},
 			path: "/images/1.jpg",
@@ -96,9 +96,32 @@ func TestProxy_Parse(t *testing.T) {
 			input:     "/images/1.jpg",
 			signature: "1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 			want: &Config{},
+			path: "/images/1.jpg",
+		},
+
+		// backward compatibility with Secret field
+		{
+			input: "/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
+			proxy: &Proxy{
+				Secret: "testsigningsecret",
+			},
+			want: &Config{
+				Width: 200,
+			},
+			path: "/images/1.jpg",
+		},
+		{
+			input: "/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
+			proxy: &Proxy{
+				SecretBytes: []byte("testsigningsecret"),
+				Secret:      "invalidsigningsecret",
+			},
+			want: &Config{
+				Width: 200,
+			},
 			path: "/images/1.jpg",
 		},
 	}
@@ -131,28 +154,28 @@ func TestProxy_Parse_sig_error(t *testing.T) {
 			// signature mismatch
 			input: "/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 		},
 		{
 			// invalid signature version
 			input: "/c/sig=Z.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 		},
 		{
 			// base64 decode error
 			input: "/c/sig=1.A/images/1.jpg",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 		},
 		{
 			input:     "/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg",
 			signature: "1.-Yd8m-5pXPihiZdlDATcwkkgjzPIC9gFHmmZ3JMxwS0=",
 			proxy: &Proxy{
-				Secret: "testsigningsecret",
+				SecretBytes: []byte("testsigningsecret"),
 			},
 		},
 	}
@@ -161,6 +184,18 @@ func TestProxy_Parse_sig_error(t *testing.T) {
 		_, err := c.proxy.Parse(c.input, c.signature)
 		if err != ErrInvalidSignature {
 			t.Errorf("%q: want ErrInvalidSignature, got %v", c.input, err)
+		}
+	}
+}
+
+func BenchmarkProxy_Parse(b *testing.B) {
+	proxy := &Proxy{
+		SecretBytes: []byte("testsigningsecret"),
+	}
+	for i := 0; i < b.N; i++ {
+		_, err := proxy.Parse("/c/sig=1.tiKX5u2kw6wp9zDgl1tLiOIi8IsoRIBw8fVgVc0yrNg=,w=200/images/1.jpg", "")
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-imageflux
cpu: Apple M1 Pro
         │  .old.txt   │              .new.txt              │
         │   sec/op    │   sec/op     vs base               │
Image-10   464.5n ± 8%   434.9n ± 5%  -6.35% (p=0.000 n=10)

         │  .old.txt  │             .new.txt              │
         │    B/op    │    B/op     vs base               │
Image-10   736.0 ± 0%   664.0 ± 0%  -9.78% (p=0.000 n=10)

         │  .old.txt   │              .new.txt              │
         │  allocs/op  │ allocs/op   vs base                │
Image-10   10.000 ± 0%   8.000 ± 0%  -20.00% (p=0.000 n=10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added binary-based signing support with a new `SecretBytes` field for proxy configuration.
* **Behavior Changes**
  * Signature generation and verification now prefer `SecretBytes` and fall back to the deprecated `Secret` when `SecretBytes` is empty.
  * If no signing secret is available, signed URL generation returns an unsigned result.
* **Tests**
  * Updated signed URL and proxy parsing test coverage to validate `SecretBytes` behavior, including backward-compatibility for `Secret`.
  * Added/updated benchmarks to exercise parsing with `SecretBytes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->